### PR TITLE
Add option to request other type of PHAsset like Video during loading

### DIFF
--- a/Example/SDWebImagePhotosPlugin/MasterViewController.m
+++ b/Example/SDWebImagePhotosPlugin/MasterViewController.m
@@ -59,6 +59,8 @@
         PHImageRequestOptions *options = [PHImageRequestOptions new];
         options.sd_targetSize = CGSizeMake(500, 500); // The original image size may be 4K, we only query the max view size :)
         SDWebImagePhotosLoader.sharedLoader.imageRequestOptions = options;
+        // Request Video Asset Poster as well
+        SDWebImagePhotosLoader.sharedLoader.requestImageAssetOnly = NO;
         
         // Photos Library Demo
         [self fetchAssets];
@@ -73,7 +75,6 @@
                                                                                           options:nil];
     PHAssetCollection *collection = result.firstObject;
     PHFetchOptions *fetchOptions = [PHFetchOptions new];
-    fetchOptions.predicate = [NSPredicate predicateWithFormat:@"mediaType = %d", PHAssetMediaTypeImage];
     fetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
     PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsInAssetCollection:collection options:fetchOptions];
     for (PHAsset *asset in assets) {

--- a/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosLoader.h
+++ b/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosLoader.h
@@ -37,4 +37,11 @@
  */
 @property (nonatomic, strong, nullable) PHImageRequestOptions *imageRequestOptions;
 
+/**
+ Whether we request only `PHAssetMediaTypeImage` asset and ignore other types (video/audio/unknown).
+ When we found other type, an error `SDWebImagePhotosErrorNotImageAsset` will be reported.
+ Defaults to YES. If you prefer to load other type like video asset's poster image, set this value to NO.
+ */
+@property (nonatomic, assign) BOOL requestImageAssetOnly;
+
 @end

--- a/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosLoader.m
+++ b/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosLoader.m
@@ -77,6 +77,7 @@ typedef CGImagePropertyOrientation SDImageOrientation;
         requestOptions.version = PHImageRequestOptionsVersionCurrent;
         self.imageRequestOptions = requestOptions;
         self.operationsTable = [NSHashTable weakObjectsHashTable];
+        self.requestImageAssetOnly = YES;
         self.fetchQueue = dispatch_queue_create("SDWebImagePhotosLoader", DISPATCH_QUEUE_SERIAL);
 #if SD_UIKIT
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
@@ -155,8 +156,8 @@ typedef CGImagePropertyOrientation SDImageOrientation;
             PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:fetchOptions];
             asset = fetchResult.firstObject;
         }
-        // Only support image
-        if (!asset || asset.mediaType != PHAssetMediaTypeImage) {
+        // Check whether we should request only image asset
+        if (!asset || (self.requestImageAssetOnly && asset.mediaType != PHAssetMediaTypeImage)) {
             // Call error
             NSError *error = [NSError errorWithDomain:SDWebImagePhotosErrorDomain code:SDWebImagePhotosErrorNotImageAsset userInfo:nil];
             if (completedBlock) {


### PR DESCRIPTION
### Feature Request
See #9 

### Solution
Add a option to disable the hard-coded filter for `image` asset. You can use Video Asset as well. And maybe some other asset type in future (like that `unkown` ?)
