### PR TITLE
Behavior changes - The default query image size now changed to PHImageManagerMaximumSize

### DIFF
--- a/Example/Tests/SDPhotosPluginTests.m
+++ b/Example/Tests/SDPhotosPluginTests.m
@@ -126,13 +126,15 @@
                                     expect(imageView.image).equal(image);
                                     // Expect animated image
                                     expect(image.sd_isAnimated).to.beTruthy();
-                                    // Clean the temp GIF asset
-                                    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-                                        PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
-                                        [PHAssetChangeRequest deleteAssets:assets];
-                                    } completionHandler:^(BOOL success, NSError * _Nullable error) {
-                                        [expectation fulfill];
-                                    }];
+                                    [expectation fulfill];
+// The removal of temp GIF will cause a GUI dialog which is not suitable for running on CI machine :(
+//                                    // Clean the temp GIF asset
+//                                    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+//                                        PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+//                                        [PHAssetChangeRequest deleteAssets:assets];
+//                                    } completionHandler:^(BOOL success, NSError * _Nullable error) {
+//                                        [expectation fulfill];
+//                                    }];
             }];
         });
     }];

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ imageView.sd_setImage(with: photosURL, placeholderImage: nil, context:[.photosIm
 #### Control Query Image Size
 The Photos taken by iPhone's Camera, its pixel size may be really large (4K+). So if you want to load large Photos Library assets for rendering, you'd better specify target size with a limited size (like you render imageView's size).
 
-By default, we query the target size matching the original image pixel size (See: `SDWebImagePhotosPixelSize`), which may consume much memory on iOS device.
+By default, we query the target size matching the original image largest size (See: [PHImageManagerMaximumSize](https://developer.apple.com/documentation/photokit/phimagemanagermaximumsize?language=objc)), which may consume much memory on iOS device. There are also two built-in dynamic value `SDWebImagePhotosPixelSize/SDWebImagePhotosPointSize` which suitable for some cases.
 
 You can change the fetch image size by either using the `PHImageRequestOptions.sd_targetSize`, or [Thumbnail Decoding](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#thumbnail-decoding-550) via `.imageThumbnailPixelSize` context option.
 

--- a/SDWebImagePhotosPlugin/Classes/PHImageRequestOptions+SDWebImagePhotosPlugin.h
+++ b/SDWebImagePhotosPlugin/Classes/PHImageRequestOptions+SDWebImagePhotosPlugin.h
@@ -12,7 +12,7 @@
 @interface PHImageRequestOptions (SDWebImagePhotosPlugin)
 
 /**
- The `targetSize` value for image asset request. Defaults to `SDWebImagePhotosPixelSize`.
+ The `targetSize` value for image asset request. Defaults to `PHImageManagerMaximumSize`.
  */
 @property (nonatomic, assign) CGSize sd_targetSize;
 

--- a/SDWebImagePhotosPlugin/Classes/PHImageRequestOptions+SDWebImagePhotosPlugin.m
+++ b/SDWebImagePhotosPlugin/Classes/PHImageRequestOptions+SDWebImagePhotosPlugin.m
@@ -15,7 +15,7 @@
 - (CGSize)sd_targetSize {
     NSValue *value = objc_getAssociatedObject(self, @selector(sd_targetSize));
     if (!value) {
-        return SDWebImagePhotosPixelSize;
+        return PHImageManagerMaximumSize;
     }
 #if SD_MAC
     CGSize targetSize = value.sizeValue;

--- a/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosDefine.h
+++ b/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosDefine.h
@@ -19,7 +19,8 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImagePhotosScheme;
 
 /**
  * Specify to use the exact size of image instead of original pixel size.
- * This is the default value if you don't specify any targetSize.
+ * Use this size if you want full image that PHImageManagerMaximumSize can not provide. This is the designed behavior for PhotoKit.
+ * @note SDWebImagePhotosPixelSize > PHImageManagerMaximumSize(default) > SDWebImagePhotosPointSize
  */
 FOUNDATION_EXPORT const CGSize SDWebImagePhotosPixelSize;
 

--- a/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosDefine.m
+++ b/SDWebImagePhotosPlugin/Classes/SDWebImagePhotosDefine.m
@@ -9,8 +9,9 @@
 #import "SDWebImagePhotosDefine.h"
 
 NSString * _Nonnull const SDWebImagePhotosScheme = @"ph";
-const CGSize SDWebImagePhotosPixelSize = {.width = 0, .height = 0};
-const CGSize SDWebImagePhotosPointSize = {.width = -1, .height = -1};
+// PHImageManagerMaximumSize value is (-1.0, -1.0)
+const CGSize SDWebImagePhotosPixelSize = {.width = -2.0, .height = -2.0};
+const CGSize SDWebImagePhotosPointSize = {.width = -3.0, .height = -3.0};
 const int64_t SDWebImagePhotosProgressExpectedSize = 100LL;
 
 SDWebImageContextOption _Nonnull const SDWebImageContextPhotosFetchOptions = @"photosFetchOptions";


### PR DESCRIPTION
This is because the previous version use `SDWebImagePhotosPixelSize`, which may return a larger size beyond system RAM limit.

For Example, if you use `SDWebImagePhotosPixelSize` to query an iPhone 5K Deep Depth Photo, iOS will return nearly 8000x8000 pixels, cause a high rate of OOM.

Use `PHImageManagerMaximumSize`, can only return you nearly 4000x4000 pixels, suitable for current iPhone's display.

This change is noticable, but it's suitable for most of common cases, we still query the as large as possible to original image by default. Only try to workaround with that OOM issue.